### PR TITLE
fix：增加 xcodebuild 脚本的鲁棒性

### DIFF
--- a/scripts/xcodebuild/build.sh
+++ b/scripts/xcodebuild/build.sh
@@ -1,30 +1,40 @@
 #!/bin/bash
-# Xcode 项目构建脚本
-## 构建参数配置
-### 项目文件路径
+
+# 调用环境检查脚本
+UTILS_DIR=$(dirname "$0")/utils
+source "$UTILS_DIR/check_xcode_env.sh"
+CHECK_RESULT=$?
+echo "CHECK_RESULT为：${CHECK_RESULT}"
+
+if [ $CHECK_RESULT -ne 0 ]; then
+    exit 1  # 环境检查失败时退出
+fi
+
+# 正常构建流程
 PROJECT_FILE="LarkClone.xcodeproj"
-
-### 构建方案（从项目文件中读取默认方案）
-BUILD_SCHEME="LarkClone"
-
-### 构建配置模式（调试/发布）
-BUILD_CONFIG="Debug"
-
-### 构建目标平台配置
-BUILD_DEST="platform=iOS Simulator,name=iPhone 16 Pro,OS=18.4,arch=arm64"
-
-## 执行 Xcode 构建命令
 echo "🏗️ 开始构建项目: ${PROJECT_FILE}"
+
+BUILD_SCHEME="LarkClone"
 echo "🔧 构建方案: ${BUILD_SCHEME}"
+
+BUILD_CONFIG="Debug"
 echo "⚙️ 构建配置: ${BUILD_CONFIG}"
+
+BUILD_DEST="platform=iOS Simulator,name=iPhone 16 Pro,OS=18.4,arch=arm64"
 echo "📱 目标设备: iPhone 16 Pro (iOS 18.4 Simulator)"
 
+# 执行 Xcode 构建命令
+echo "🏗️  Building project..."
 xcodebuild \
-  -project "${PROJECT_FILE}" \
-  -scheme "${BUILD_SCHEME}" \
-  -configuration ${BUILD_CONFIG} \
-  -destination "${BUILD_DEST}" \
+  -project "$PROJECT_FILE" \
+  -scheme "$BUILD_SCHEME" \
+  -configuration "$BUILD_CONFIG" \
+  -destination "$BUILD_DEST" \
   build
 
-echo "✅ 构建命令已执行完成"
-```
+if [ $? -eq 0 ]; then
+    echo "✅ Build succeeded"
+else
+    echo "❌ Build failed"
+    exit 1
+fi

--- a/scripts/xcodebuild/utils/check_xcode_env.sh
+++ b/scripts/xcodebuild/utils/check_xcode_env.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# 返回值通过 return 而不是 exit 传递
+
+check_xcode_env() {
+    # 检查 xcodebuild 是否存在
+    if ! command -v xcodebuild &>/dev/null; then
+        echo "❌ Error: xcodebuild not found"
+        return 1
+    fi
+
+    # 检查当前是否是 Command Line Tools
+    ACTIVE_DIR=$(xcode-select -p)
+    if [[ ! "$ACTIVE_DIR" == *"Xcode.app"* ]]; then
+        echo "⚠️ Switching to Xcode..."
+        if ! sudo xcode-select -s /Applications/Xcode.app/Contents/Developer 2>/dev/null; then
+            echo "❌ Failed to switch Xcode path"
+            return 2
+        fi
+        echo "✅ Switched to: $(xcode-select -p)"
+    fi
+
+    # 检查许可协议
+    if ! xcodebuild -license check &>/dev/null; then
+        echo "⚠️ Accepting Xcode license..."
+        if ! sudo xcodebuild -license accept; then
+            echo "❌ Failed to accept license"
+            return 3
+        fi
+    fi
+
+    echo "✅ Xcode environment check passed"
+    return 0
+}
+
+# 执行检查（不再使用 exit）
+check_xcode_env


### PR DESCRIPTION
对于不同的主机，Xcode的环境可能不同。

如果当前的Xcode是 Command Line Tool ，同时已经安装了Xcode，那么应该将 Xcode 的路径进行修正

```bash
sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
```

`check_xcode_env.sh` 脚本在 `build.sh` 脚本中调用，用于检查 Xcode 环境。